### PR TITLE
hotfix: don't bump MIN_PERL_VERSION in Makefile.PL

### DIFF
--- a/lib/Distar/helpers/bump-version
+++ b/lib/Distar/helpers/bump-version
@@ -84,7 +84,7 @@ my $FILE_RE = qr{
   (.*)$
 }x;
 my $MAKE_RE = qr{
-  (^.* ['"]?(?:version|VERSION)['"]? \s* => \s* )
+  (^\s* ['"]?(?:version|VERSION)['"]? \s* => \s* )
   (['"]?) v?([0-9]+(?:[._][0-9]+)*) \2
   ( \s*, )
   (?:


### PR DESCRIPTION
the current regex used to find VERSION in Makefile.PL is too naive, and tries to bump
MIN_PERL_VERSION too. 
I changed the regex to only allow beggining of the line space.

LMK if the more correct change would be to disallow an underscore before the word VERSION.
I'm fresh from the dzil land, so I don't know if most Makefile.PLs have multiple EUMM args
on the same line or not.
